### PR TITLE
change log level for docker container logs to debug

### DIFF
--- a/src/main/scala/fr/vsct/dt/maze/topology/Docker.scala
+++ b/src/main/scala/fr/vsct/dt/maze/topology/Docker.scala
@@ -292,7 +292,7 @@ object Docker extends LazyLogging {
       .exec(new LogAppender).await()
       .result.split("\n")
 
-    logger.info(s"Got logs for container $id: ${logs.mkString("\n")}")
+    logger.debug(s"Got logs for container $id: ${logs.mkString("\n")}")
     logs
   }.labeled(s"logs of container $id")
 


### PR DESCRIPTION
Avoir les logs de tous les containers c'est vraiment très verbeux. Je propose de passer en DEBUG.
On pourra ainsi plus facilement les filtrer