### PR TITLE
remove this logs, because it too huge

### DIFF
--- a/src/main/scala/fr/vsct/dt/maze/topology/Docker.scala
+++ b/src/main/scala/fr/vsct/dt/maze/topology/Docker.scala
@@ -292,6 +292,9 @@ object Docker extends LazyLogging {
       .exec(new LogAppender).await()
       .result.split("\n")
 
+    logger.trace(s"Got logs for container $id: ${logs.mkString("\n")}")
     logs
   }.labeled(s"logs of container $id")
+
 }
+

--- a/src/main/scala/fr/vsct/dt/maze/topology/Docker.scala
+++ b/src/main/scala/fr/vsct/dt/maze/topology/Docker.scala
@@ -292,9 +292,6 @@ object Docker extends LazyLogging {
       .exec(new LogAppender).await()
       .result.split("\n")
 
-    logger.debug(s"Got logs for container $id: ${logs.mkString("\n")}")
     logs
   }.labeled(s"logs of container $id")
-
 }
-


### PR DESCRIPTION
Ce log fait pas sens. Il est trop gros, et si on l'a c'est qu'on a l'info dans une variable qu'on peux printer